### PR TITLE
RiscVPkg: Implement ResetSystem RuntimeService

### DIFF
--- a/RiscVPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/RiscVPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -1,0 +1,124 @@
+/** @file
+  Reset System Library functions for RISC-V
+
+  Copyright (c) 2020, Hewlett Packard Development LP. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/ResetSystemLib.h>
+#include <IndustryStandard/RiscVOpensbi.h>
+
+/**
+  This function causes a system-wide reset (cold reset), in which
+  all circuitry within the system returns to its initial state. This type of reset
+  is asynchronous to system operation and operates without regard to
+  cycle boundaries.
+
+  If this function returns, it means that the system does not support cold reset.
+**/
+VOID
+EFIAPI
+ResetCold (
+  VOID
+  )
+{
+  // SBI does not define a cold reset
+  // OpenSBI, however, does offer a reboot function
+}
+
+/**
+  This function causes a system-wide initialization (warm reset), in which all processors
+  are set to their initial state. Pending cycles are not corrupted.
+
+  If this function returns, it means that the system does not support warm reset.
+**/
+VOID
+EFIAPI
+ResetWarm (
+  VOID
+  )
+{
+  // SBI does not define a warm reset
+}
+
+/**
+  This function causes the system to enter a power state equivalent
+  to the ACPI G2/S5 or G3 states.
+
+  If this function returns, it means that the system does not support shutdown reset.
+**/
+VOID
+EFIAPI
+ResetShutdown (
+  VOID
+  )
+{
+  // Shut down via SBI ecall
+  sbi_shutdown();
+}
+
+/**
+  This function causes a systemwide reset. The exact type of the reset is
+  defined by the EFI_GUID that follows the Null-terminated Unicode string passed
+  into ResetData. If the platform does not recognize the EFI_GUID in ResetData
+  the platform must pick a supported reset type to perform.The platform may
+  optionally log the parameters from any non-normal reset that occurs.
+
+  @param[in]  DataSize   The size, in bytes, of ResetData.
+  @param[in]  ResetData  The data buffer starts with a Null-terminated string,
+                         followed by the EFI_GUID.
+**/
+VOID
+EFIAPI
+ResetPlatformSpecific (
+  IN UINTN   DataSize,
+  IN VOID    *ResetData
+  )
+{
+  ResetShutdown ();
+}
+
+/**
+  The ResetSystem function resets the entire platform.
+
+  @param[in] ResetType      The type of reset to perform.
+  @param[in] ResetStatus    The status code for the reset.
+  @param[in] DataSize       The size, in bytes, of ResetData.
+  @param[in] ResetData      For a ResetType of EfiResetCold, EfiResetWarm, or EfiResetShutdown
+                            the data buffer starts with a Null-terminated string, optionally
+                            followed by additional binary data. The string is a description
+                            that the caller may use to further indicate the reason for the
+                            system reset.
+**/
+VOID
+EFIAPI
+ResetSystem (
+  IN EFI_RESET_TYPE               ResetType,
+  IN EFI_STATUS                   ResetStatus,
+  IN UINTN                        DataSize,
+  IN VOID                         *ResetData OPTIONAL
+  )
+{
+  switch (ResetType) {
+  case EfiResetWarm:
+    ResetWarm ();
+    break;
+
+  case EfiResetCold:
+    ResetCold ();
+    break;
+
+  case EfiResetShutdown:
+    ResetShutdown ();
+    return;
+
+  case EfiResetPlatformSpecific:
+    ResetPlatformSpecific (DataSize, ResetData);
+    return;
+
+  default:
+    return;
+  }
+}

--- a/RiscVPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/RiscVPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -1,0 +1,33 @@
+## @file
+#  Library instance for ResetSystem library class for OVMF
+#
+#  Copyright (c) 2020, Hewlett Packard Enterprise Developmente LP. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ResetSystemLib
+  FILE_GUID                      = 3eff6057-1116-4dcb-837e-c0ef1a120ab1
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ResetSystemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  ResetSystemLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RiscVPkg/RiscVPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  RiscVOpensbiLib

--- a/RiscVPkg/RiscVPkg.dsc
+++ b/RiscVPkg/RiscVPkg.dsc
@@ -82,11 +82,18 @@
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   TimerLib|RiscVPkg/Library/RiscVTimerLib/BaseRiscVTimerLib.inf
+  ResetSystemLib|RiscVPkg/Library/ResetSystemLib/ResetSystemLib.inf
+  UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+  ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
 
 [LibraryClasses.common.UEFI_DRIVER]
   TimerLib|RiscVPkg/Library/RiscVTimerLib/BaseRiscVTimerLib.inf
 
 [Components]
+  #
+  # DXE Phase modules
+  #
   RiscVPkg/Universal/CpuDxe/CpuDxe.inf
   RiscVPkg/Universal/SmbiosDxe/RiscVSmbiosDxe.inf
+  MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
 


### PR DESCRIPTION
When executing the `reset` command in the UEFI shell, the debug message is printed but the VM gets stuck. Not sure whether that's my implementation fault or OpenSBI&QEMU.

To try this PR, the following patch also needs to be applied to edk2-platforms:

```diff
--- i/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
+++ w/Platform/SiFive/U5SeriesPkg/FreedomU540HiFiveUnleashedBoard/U540.dsc
@@ -427,7 +427,8 @@
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf {
     <LibraryClasses>
-      ResetSystemLib|MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf
+      ResetSystemLib|RiscVPkg/Library/ResetSystemLib/ResetSystemLib.inf
   }
   EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
```